### PR TITLE
acpi-tables.bb extended with package generation and scripts

### DIFF
--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -10,6 +10,12 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD;md5=377548
 
 DEPENDS = "acpica-native"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
+SRC_URI = "\
+	file://acpi-tables-load.service \
+	file://acpi-tables-load \
+"
+
 B = "${WORKDIR}/acpi-tables"
 
 inherit deploy
@@ -45,9 +51,16 @@ do_install() {
 		dest_table=$(basename $table asl)
 		install -m 644 ${B}/kernel/firmware/acpi/${dest_table}aml ${D}/kernel/firmware/acpi/${dest_table}aml
 	done
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/acpi-tables-load ${D}${bindir}
+	install -d ${D}/${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/acpi-tables-load.service ${D}/${systemd_unitdir}/system
+
 }
 
 FILES_${PN} = "/kernel/firmware/acpi"
+FILES_${PN} += "${systemd_unitdir}/system/*"
+FILES_${PN} += "${bindir}/*"
 
 do_deploy() {
 	cd ${WORKDIR}/acpi-tables

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -10,6 +10,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD;md5=377548
 
 DEPENDS = "acpica-native"
 
+B = "${WORKDIR}/acpi-tables"
+
 inherit deploy
 
 ACPI_TABLES ?= ""
@@ -35,6 +37,17 @@ do_compile() {
 		iasl -p ${WORKDIR}/acpi-tables/kernel/firmware/acpi/$dest_table $table
 	done
 }
+
+do_install() {
+
+	install -d ${D}/kernel/firmware/acpi
+	for table in ${ACPI_TABLES}; do
+		dest_table=$(basename $table asl)
+		install -m 644 ${B}/kernel/firmware/acpi/${dest_table}aml ${D}/kernel/firmware/acpi/${dest_table}aml
+	done
+}
+
+FILES_${PN} = "/kernel/firmware/acpi"
 
 do_deploy() {
 	cd ${WORKDIR}/acpi-tables

--- a/recipes-bsp/acpi-tables/files/acpi-tables-load
+++ b/recipes-bsp/acpi-tables/files/acpi-tables-load
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This script copies all ACPI tables into /kernel/firmware/acpi
+# You must have configfs enabled for this to work
+
+    for TABLE in `ls /kernel/firmware/acpi/ 2>/dev/null`; do
+	dest_dir=$(basename $TABLE .aml)
+	mkdir /sys/kernel/config/acpi/table/$dest_dir
+	cat /kernel/firmware/acpi/$TABLE > /sys/kernel/config/acpi/table/$dest_dir/aml
+    done
+

--- a/recipes-bsp/acpi-tables/files/acpi-tables-load.service
+++ b/recipes-bsp/acpi-tables/files/acpi-tables-load.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=ACPI tables load service
+
+[Service]
+ExecStart=/usr/bin/acpi-tables-load
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target
+

--- a/recipes-bsp/acpi-tables/samples/edison/ads7951.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/ads7951.asli
@@ -1,0 +1,65 @@
+/*
+ * Intel Edison
+ *
+ * This adds Texas Instruments ADS7950 family of A/DC chips to the SPI host
+ * controller available on Intel Edison/Arduino board.
+ *
+ * In Linux you need to set CONFIG_TI_ADS7950=y (or m) to be able to use
+ * this device.
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Include this file from an ASL providing SSDT DefinitionBlock.
+ */
+External (_SB_.PCI0.SPI5, DeviceObj)
+
+Scope (\_SB.PCI0.SPI5)
+{
+    Device (ADC0) {
+        Name (_HID, "PRP0001")
+        Name (_DDN, "Texas Instruments ADS7950 family of A/DC chips")
+        Name (_CRS, ResourceTemplate () {
+            SpiSerialBus (
+                0,                      // Chip select
+                PolarityLow,            // Chip select is active low
+                FourWireMode,           // Full duplex
+                8,                      // Bits per word is 8 (byte)
+                ControllerInitiated,    // Don't care
+                20000000,               // 20 MHz
+                ClockPolarityLow,       // SPI mode 0
+                ClockPhaseFirst,        // SPI mode 0
+                "\\_SB.PCI0.SPI5",      // SPI host controller
+                0                       // Must be 0
+            )
+        })
+
+        /*
+         * See Documentation/devicetree/bindings/iio/adc/ti-ads7950.txt for
+         * more information about these bindings.
+         */
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"compatible", Package () {"ti,ads7951"}},
+            }
+        })
+    }
+}

--- a/recipes-bsp/acpi-tables/samples/edison/arduino.asl
+++ b/recipes-bsp/acpi-tables/samples/edison/arduino.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel Edison
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+DefinitionBlock ("arduino.aml", "SSDT", 5, "", "ARDUINO", 1)
+{
+    #include "arduino.asli"
+}

--- a/recipes-bsp/acpi-tables/samples/edison/arduino.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/arduino.asli
@@ -1,0 +1,349 @@
+/*
+ * Intel Edison
+ *
+ * Provides support for devices found on Intel Edison/Arduino board.
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Some preprocessor magic to convert the symbol to either 0 or 1 so that
+ * preprocessor #if works properly.
+ */
+#ifdef MUX_I2C
+#undef MUX_I2C
+#define MUX_I2C 1
+#else
+#define MUX_I2C 0
+#endif
+
+#ifdef MUX_SPI
+#undef MUX_SPI
+#define MUX_SPI 1
+#else
+#define MUX_SPI 0
+#endif
+
+#ifdef MUX_UART1
+#undef MUX_UART1
+#define MUX_UART1 1
+#else
+#define MUX_UART1 0
+#endif
+
+External (_SB_.PCI0.I2C1, DeviceObj)
+
+Scope (\_SB.PCI0.I2C1)
+{
+    #include "gpioexp.asli"
+
+    // GPIO expander (U17)
+    Scope (NIO1)
+    {
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {
+                    "gpio-line-names",
+                    Package () {
+                       "MUX15_SEL",
+                       "MUX13_SEL",
+                       "MUX11_SEL",
+                       "MUX9_SEL",
+                       "MUX7_SEL",
+                       "MUX5_SEL",
+                       "U17_IO0.6",
+                       "SHLD_RESET0",
+                       "A0_PU_PD",
+                       "A1_PU_PD",
+                       "A2_PU_PD",
+                       "A3_PU_PD",
+                       "A4_PU_PD",
+                       "A5_PU_PD",
+                       "TRI_STATE_ALL",
+                       "SHLD_RESET1",
+                    }
+                },
+            },
+#if MUX_SPI || MUX_UART1
+            ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
+            Package () {
+#if MUX_SPI
+                Package () {"spi-mosi-oe", "SMOE"},
+                Package () {"spi-mosi-pu", "SMPU"},
+                Package () {"spi-cs-oe", "SSOE"},
+                Package () {"spi-cs-pu", "SSPU"},
+                Package () {"spi-sck-oe", "SCOE"},
+                Package () {"spi-sck-pu", "SCPU"},
+#endif
+#if MUX_UART1
+                Package () {"uart1-tx-oe", "U1OE"},
+                Package () {"uart1-tx-pu", "U1PU"},
+#endif
+            }
+#endif
+        })
+
+#if MUX_SPI
+        // Enable ouput and disable pullup from SPI MOSI (IO11)
+        Name (SMOE, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {8, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-mosi-oe"},
+            }
+        })
+
+        Name (SMPU, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {9, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-mosi-pu"},
+            }
+        })
+
+        // Enable ouput and pullup from SPI CS (IO10)
+        Name (SSOE, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {10, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-cs-oe"},
+            }
+        })
+
+        Name (SSPU, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {11, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-cs-pu"},
+            }
+        })
+
+        // Enable ouput and disable pullup from SPI SCK (IO13)
+        Name (SCOE, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {14, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-sck-oe"},
+            }
+        })
+
+        Name (SCPU, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {15, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "spi-sck-pu"},
+            }
+        })
+#endif
+
+#if MUX_UART1
+        // Enable output
+        Name (U1OE, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {0, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "uart1-tx-oe"},
+            }
+        })
+
+        // Disable pullup
+        Name (U1PU, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"gpio-hog", 1},
+                Package () {"gpios", Package () {1, 0}},
+                Package () {"output-low", 1},
+                Package () {"line-name", "uart1-tx-pu"},
+            }
+        })
+#endif
+    }
+
+    // GPIO expander (U39)
+    Scope (NIO2)
+    {
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {
+                    "gpio-line-names",
+                    Package () {
+                       "DIG0_PU_PD",
+                       "DIG1_PU_PD",
+                       "DIG2_PU_PD",
+                       "DIG3_PU_PD",
+                       "DIG4_PU_PD",
+                       "DIG5_PU_PD",
+                       "DIG6_PU_PD",
+                       "DIG7_PU_PD",
+                       "DIG8_PU_PD",
+                       "DIG9_PU_PD",
+                       "DIG10_PU_PD",
+                       "DIG11_PU_PD",
+                       "DIG12_PU_PD",
+                       "DIG13_PU_PD",
+                       "U39_IO1.6",
+                       "U39_IO1.7",
+                    }
+                },
+            },
+        })
+    }
+
+    // GPIO expander (U16)
+    Scope (NIO3)
+    {
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {
+                    "gpio-line-names",
+                    Package () {
+                       "MUX14_DIR",
+                       "MUX12_DIR",
+                       "MUX10_DIR",
+                       "MUX8_DIR",
+                       "MUX6_DIR",
+                       "MUX4_DIR",
+                       "U16_IO0.6",
+                       "U16_IO0.7",
+                       "SPI_FS_SEL",
+                       "SPI_TXD_SEL",
+                       "SPI_RXD_SEL",
+                       "SPI_CLK_SEL",
+                       "U16_IO1.4",
+                       "U16_IO1.5",
+                       "U16_IO1.6",
+                       "U16_IO1.7",
+                    }
+                },
+            },
+        })
+    }
+
+    // GPIO expander (U34)
+    Scope (NIO4)
+    {
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {
+                    "gpio-line-names",
+                    Package () {
+                       "MUX33_DIR",
+                       "MUX31_DIR",
+                       "MUX29_DIR",
+                       "MUX27_DIR",
+                       "MUX24_DIR",
+                       "MUX21_DIR",
+                       "MUX19_DIR",
+                       "MUX32_DIR",
+                       "MUX30_DIR",
+                       "MUX28_DIR",
+                       "MUX26_DIR",
+                       "MUX23_DIR",
+                       "MUX20_DIR",
+                       "MUX18_DIR",
+                       "MUX22_SEL",
+                       "MUX25_SEL",
+                    }
+                },
+            },
+        })
+    }
+}
+
+/* Texas Instruments ADS7950 family of A/DC chips */
+#include "ads7951.asli"
+
+External (_SB_.PCI0.PWM0, DeviceObj)
+
+Scope (\_SB.PCI0.PWM0)
+{
+    Name (RBUF, ResourceTemplate ()
+    {
+        PinFunction(Exclusive, PullUp, 0x0001,
+            "\\_SB.FLIS", 0, ResourceConsumer, , ) { 144 }
+        PinFunction(Exclusive, PullUp, 0x0001,
+            "\\_SB.FLIS", 0, ResourceConsumer, , ) { 145 }
+        PinFunction(Exclusive, PullUp, 0x0001,
+            "\\_SB.FLIS", 0, ResourceConsumer, , ) { 132 }
+        PinFunction(Exclusive, PullUp, 0x0001,
+            "\\_SB.FLIS", 0, ResourceConsumer, , ) { 133 }
+    })
+    Method (_CRS, 0, NotSerialized)
+    {
+        Return (RBUF)
+    }
+}
+
+External (_SB_.PCI0, DeviceObj)
+
+Scope (\_SB.PCI0)
+{
+    Device (SPI6)
+    {
+        Name (_ADR, 0x00070002)
+        Name (RBUF, ResourceTemplate()
+        {
+            PinFunction(Exclusive, PullUp, 0x0001,
+                "\\_SB.FLIS", 0, ResourceConsumer, , ) { 97, 100, 99 }
+            GpioIo(Exclusive, PullUp, 0, 0, IoRestrictionOutputOnly,
+                "\\_SB.PCI0.GPIO", 0, ResourceConsumer, , ) { 117 }
+        })
+
+        Method (_CRS, 0, NotSerialized)
+        {
+            Return (RBUF)
+        }
+
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {
+                    "cs-gpios", Package () {
+                        ^SPI6, 0, 0, 0,
+                    },
+                },
+            }
+        })
+
+        Method (_STA, 0, NotSerialized)
+        {
+            Return (0xF)
+        }
+    }
+}

--- a/recipes-bsp/acpi-tables/samples/edison/gpioexp.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/gpioexp.asli
@@ -1,0 +1,117 @@
+/*
+ * Intel Edison
+ *
+ * Provides GPIO expanders and names for all GPIO pins.
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Include this file from an ASL providing SSDT DefinitionBlock.
+ */
+
+Device (NIO1)
+{
+    Name (_HID, "INT3491")
+    Name (_CID, "INT3491")
+    Name (_UID, One)
+    Name (RBUF, ResourceTemplate()
+    {
+        I2cSerialBusV2(0x0020, ControllerInitiated, 400000,
+            AddressingMode7Bit, "\\_SB.PCI0.I2C1",
+            0x00, ResourceConsumer, , Exclusive, )
+        GpioInt(Level, ActiveLow, Exclusive, PullDefault, 0x0000,
+            "\\_SB.PCI0.GPIO", 0x00, ResourceConsumer, , ) { 15 }
+    })
+    Method (_CRS, 0, NotSerialized)
+    {
+        Return (RBUF)
+    }
+
+    Method (_STA, 0, NotSerialized)
+    {
+        Return (0x0F)
+    }
+}
+
+Device (NIO2)
+{
+    Name (_HID, "INT3491")
+    Name (_CID, "INT3491")
+    Name (_UID, 0x02)
+    Name (RBUF, ResourceTemplate()
+    {
+        I2cSerialBusV2(0x0021, ControllerInitiated, 400000,
+            AddressingMode7Bit, "\\_SB.PCI0.I2C1",
+            0x00, ResourceConsumer, , Exclusive, )
+    })
+    Method (_CRS, 0, NotSerialized)
+    {
+        Return (RBUF)
+    }
+
+    Method (_STA, 0, NotSerialized)
+    {
+        Return (0x0F)
+    }
+}
+
+Device (NIO3)
+{
+    Name (_HID, "INT3491")
+    Name (_CID, "INT3491")
+    Name (_UID, 0x03)
+    Name (RBUF, ResourceTemplate()
+    {
+        I2cSerialBusV2(0x0022, ControllerInitiated, 400000,
+            AddressingMode7Bit, "\\_SB.PCI0.I2C1",
+            0x00, ResourceConsumer, , Exclusive, )
+    })
+    Method (_CRS, 0, NotSerialized)
+    {
+        Return (RBUF)
+    }
+
+    Method (_STA, 0, NotSerialized)
+    {
+        Return (0x0F)
+    }
+}
+
+Device (NIO4)
+{
+    Name (_HID, "INT3491")
+    Name (_CID, "INT3491")
+    Name (_UID, 0x04)
+    Name (RBUF, ResourceTemplate()
+    {
+        I2cSerialBusV2(0x0023, ControllerInitiated, 400000,
+            AddressingMode7Bit, "\\_SB.PCI0.I2C1",
+            0x00, ResourceConsumer, , Exclusive, )
+    })
+    Method (_CRS, 0, NotSerialized)
+    {
+        Return (RBUF)
+    }
+
+    Method (_STA, 0, NotSerialized)
+    {
+        Return (0x0F)
+    }
+}

--- a/recipes-bsp/acpi-tables/samples/edison/spidev.asl
+++ b/recipes-bsp/acpi-tables/samples/edison/spidev.asl
@@ -1,0 +1,56 @@
+/*
+ * Intel Edison
+ *
+ * This adds raw SPI test device to the SPI host controller available on
+ * Edison I/O connector.
+ *
+ * In Linux you need to set CONFIG_SPI_SPIDEV=y (or m) to be able to use
+ * this device.
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+DefinitionBlock ("spidev.aml", "SSDT", 5, "", "SPIDEV", 1)
+{
+    External (_SB_.PCI0.SPI5, DeviceObj)
+
+    Scope (\_SB.PCI0.SPI5)
+    {
+        Device (TP0)
+        {
+            Name (_HID, "SPT0001")
+            Name (_DDN, "SPI test device")
+            Name (_CRS, ResourceTemplate () {
+                SpiSerialBus (
+                    1,                      // Chip select
+                    PolarityLow,            // Chip select is active low
+                    FourWireMode,           // Full duplex
+                    8,                      // Bits per word is 8 (byte)
+                    ControllerInitiated,    // Don't care
+                    1000000,                // 1 MHz
+                    ClockPolarityLow,       // SPI mode 0
+                    ClockPhaseFirst,        // SPI mode 0
+                    "\\_SB.PCI0.SPI5",      // SPI host controller
+                    0                       // Must be 0
+                )
+            })
+        }
+    }
+}


### PR DESCRIPTION
@andy-shev This is on top of the patches I added earlier to include edison sample tables.

Heads up - I rebased today on westeri/meta-acpi/master.

I extended the original recipe with building a package (the package type is selected elsewhere in the config, YP default is ipk but we use deb). This does not change anything to the generated cpio. 

The generated package sits harmless in the YP build system and is only installed when added to the system image edison-image.bb using IMAGE_INSTALL += "acpi-tables" or better IMAGE_INSTALL_append as I learned from @alext-mkrs.

This also installs a systemd service that can be enabled to start on boot and executes a script that copies all acpi-tables to configfs.

Additional aml's can also be copied manually to /kernel/firmware/acpi/ and will be loaded into the kernel on the next reboot. Also I think users should be able to easily bbappend the recipy to add their own asl tables for inclusion into their system image.

I tested this by manually building `'bitbake acpi-tables'`, copying the `acpi-tables_1.0-r0_amd64.deb` over to edison and install using `'dpkg -i acpi-tables_1.0-r0_amd64.deb'`

With this extension to the meta-acpi layer and configfs enabled in the kernel we have acpi support working for edison. Functionally nothing else is needed. I hope @alext-mkrs is willing to review this.

Also this same method should work on the other supported platforms as well when configfs is enabled, it is independent of the boot loader and kernel image generation.
