### PR TITLE
Eds 5.0.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,3 +10,4 @@ BBFILE_PATTERN_acpi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_acpi = "6"
 
 LAYERDEPENDS_acpi = "intel"
+LAYERSERIES_COMPAT_acpi = "rocko sumo thud"

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -10,6 +10,13 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD;md5=377548
 
 DEPENDS = "acpica-native"
 
+SRC_URI = "\
+	file://acpi-tables-load.service \
+	file://acpi-tables-load \
+"
+
+B = "${WORKDIR}/acpi-tables"
+
 inherit deploy
 
 ACPI_TABLES ?= ""
@@ -44,6 +51,24 @@ do_compile() {
 		iasl ${IASLFLAGS} -p ${WORKDIR}/acpi-tables/kernel/firmware/acpi/$dest_table $table
 	done
 }
+
+do_install() {
+
+	install -d ${D}/kernel/firmware/acpi
+	for table in ${ACPI_TABLES}; do
+		dest_table=$(basename $table .asl)
+		install -m 644 ${B}/kernel/firmware/acpi/${dest_table}.aml ${D}/kernel/firmware/acpi/${dest_table}.aml
+	done
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/acpi-tables-load ${D}${bindir}
+	install -d ${D}/${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/acpi-tables-load.service ${D}/${systemd_unitdir}/system
+
+}
+
+FILES_${PN} = "/kernel/firmware/acpi"
+FILES_${PN} += "${systemd_unitdir}/system/*"
+FILES_${PN} += "${bindir}/*"
 
 do_deploy() {
 	cd ${WORKDIR}/acpi-tables

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -14,6 +14,14 @@ inherit deploy
 
 ACPI_TABLES ?= ""
 ACPI_TABLES[doc] = "List of ACPI tables to include with the initrd"
+ACPI_FEATURES_edison ?= "uart_2w spi i2c"
+IASLFLAGS = " \
+    ${@bb.utils.contains('ACPI_FEATURES', 'uart_2w', '-DMUX_UART_2WIRE', '', d)} \
+    ${@bb.utils.contains('ACPI_FEATURES', 'uart_4w', '-DMUX_UART_4WIRE', '', d)} \
+    ${@bb.utils.contains('ACPI_FEATURES', 'i2c', '-DMUX_I2C', '', d)} \
+    ${@bb.utils.contains('ACPI_FEATURES', 'spi', '-DMUX_SPI', '', d)} \
+    ${@bb.utils.contains('ACPI_FEATURES', 'uart0', '-DMUX_UART0', '', d)} \
+"
 
 do_compile() {
 	# Always clean up the existing tables
@@ -32,7 +40,8 @@ do_compile() {
 
 		dest_table=$(basename $table)
 		bbdebug 1 "Including ACPI table: ${table}"
-		iasl -p ${WORKDIR}/acpi-tables/kernel/firmware/acpi/$dest_table $table
+		bbdebug 1 "Setting iasl compiler defines: ${IASLFLAGS}"
+		iasl ${IASLFLAGS} -p ${WORKDIR}/acpi-tables/kernel/firmware/acpi/$dest_table $table
 	done
 }
 

--- a/recipes-bsp/acpi-tables/files/acpi-tables-load
+++ b/recipes-bsp/acpi-tables/files/acpi-tables-load
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This script copies all ACPI tables into /kernel/firmware/acpi
+# You must have configfs enabled for this to work
+
+    for TABLE in `find /kernel/firmware/acpi/ -type f -name "*.aml"  2>/dev/null`; do
+        dest_dir=$(basename $TABLE .aml)
+        mkdir /sys/kernel/config/acpi/table/$dest_dir
+        cat $TABLE > /sys/kernel/config/acpi/table/$dest_dir/aml
+    done
+

--- a/recipes-bsp/acpi-tables/files/acpi-tables-load.service
+++ b/recipes-bsp/acpi-tables/files/acpi-tables-load.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=ACPI tables load service
+
+[Service]
+ExecStart=/usr/bin/acpi-tables-load
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target
+

--- a/recipes-bsp/acpi-tables/samples/edison/arduino-all.asl
+++ b/recipes-bsp/acpi-tables/samples/edison/arduino-all.asl
@@ -23,5 +23,9 @@
  */
 DefinitionBlock ("arduino.aml", "SSDT", 5, "", "ARDUINO", 1)
 {
+    #define MUX_I2C
+    #define MUX_SPI
+    #define MUX_UART_4WIRE
+
     #include "arduino.asli"
 }

--- a/recipes-bsp/acpi-tables/samples/edison/ds2-led.asl
+++ b/recipes-bsp/acpi-tables/samples/edison/ds2-led.asl
@@ -1,0 +1,28 @@
+/*
+ * Intel Edison
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+DefinitionBlock ("ds2-led.aml", "SSDT", 5, "", "DS2-LED", 1)
+{
+    #include "arduino.asli"
+    #include "leds.asli"
+}

--- a/recipes-bsp/acpi-tables/samples/edison/leds.asl
+++ b/recipes-bsp/acpi-tables/samples/edison/leds.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel Edison
+ *
+ * Copyright (C) 2017, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+DefinitionBlock ("leds.aml", "SSDT", 5, "", "LEDS", 1)
+{
+    #include "leds.asli"
+}

--- a/recipes-bsp/acpi-tables/samples/edison/leds.asli
+++ b/recipes-bsp/acpi-tables/samples/edison/leds.asli
@@ -1,0 +1,85 @@
+/*
+ * Intel Edison
+ *
+ * This table is modified from the Minnowboard Max leds.asl for Edison.
+ * 
+ * According to Intel® Edison Kit for Arduino Hardware Guide March 2017
+ * DS2 is the standard LED on the Arduino* board.
+ * It runs using the ‘blink’ code or whenever Digital I/O 13 is asserted High. 
+ * It can be used as an indicator under direct control.
+ * 
+ * This adds GPIO LEDs device for the DS2 LED and sets default heartbeat
+ * trigger for that.
+ *
+ * In Linux you need to set CONFIG_LEDS_GPIO=y (or m) to be able to use
+ * this device.
+ *
+ * Copyright (C) 2016, Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+Scope (_SB)
+{
+    Device (LEDS)
+    {
+        Name (_HID, "PRP0001")
+        Name (_DDN, "GPIO LEDs device")
+
+        Name (_CRS, ResourceTemplate () {
+            GpioIo (
+                Exclusive,                  // Not shared
+                PullNone,                   // No need for pulls
+                0,                          // Debounce timeout
+                0,                          // Drive strength
+                IoRestrictionOutputOnly,    // Only used as output
+                "\\_SB.PCI0.GPIO",          // GPIO controller
+                0)                          // Must be 0
+            {
+                40,                         // GP40_I2S_2_CLK
+            }
+        })
+
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"compatible", "gpio-leds"},
+            },
+            ToUUID("dbb8e3e6-5886-4ba6-8795-1319f52a966b"),
+            Package () {
+                Package () {"led-0", "LED0"},
+            }
+        })
+
+        /*
+            * For more information about these bindings see:
+            * Documentation/devicetree/bindings/leds/leds-gpio.txt and
+            * Documentation/acpi/gpio-properties.txt.
+            */
+        Name (LED0, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () {"label", "heartbeat"},
+                Package () {"gpios", Package () {^LEDS, 0, 0, 1}},
+                Package () {"linux,default-state", "off"},
+                Package () {"linux,default-trigger", "heartbeat"},
+                Package () {"linux,retain-state-suspended", 1},
+            }
+        })
+    }
+}

--- a/recipes-bsp/acpica/acpica_20190215.bb
+++ b/recipes-bsp/acpica/acpica_20190215.bb
@@ -18,8 +18,8 @@ DEPENDS = "bison flex"
 
 SRC_URI = "https://acpica.org/sites/acpica/files/acpica-unix2-${PV}.tar.gz \
     "
-SRC_URI[md5sum] = "5aa086f71f4b5273c0932a1e04419a37"
-SRC_URI[sha256sum] = "d1e26cdde58938653a277a5ca59ce1df045508d345fee13fed2eaacc6ef51851"
+SRC_URI[md5sum] = "0ea9047bf15dfdf3583f5266cc6da718"
+SRC_URI[sha256sum] = "8f939ad6130862e05853837496500b3fb93037530e5ea0ca0298458522ffc2c7"
 UPSTREAM_CHECK_URI = "https://acpica.org/downloads"
 
 S = "${WORKDIR}/acpica-unix2-${PV}"


### PR DESCRIPTION
These changes are targeting Edison with linux 5.0.0 built with Yocto Thud.
1. provides a more recent acpica then OE-Core master (20180508).
2. is generic and needed for sumo and later, otherwise errors are generated
3. and 
4. make the control of the defines through a Yocto variable, prevents needing to edit the asl
5. and 
6. provides 2 more sample tables
7. the recipe as is generates a cpio, this change generates a Package as well containing load script and systemd service for use with configfs. Package can be added to image or initramfs as usual (or not if not needed)
8. Eds needs TRI_STATE_ALL in the load script. If we want this script usable on other platforms we will need some conditional here. Also, this creates a dependency on libgpiod.