### PR TITLE
Hardknott for Edison

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_acpi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_acpi = "6"
 
 LAYERDEPENDS_acpi = "intel"
-LAYERSERIES_COMPAT_acpi = "rocko sumo thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_acpi = "dunfell"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_acpi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_acpi = "6"
 
 LAYERDEPENDS_acpi = "intel"
-LAYERSERIES_COMPAT_acpi = "dunfell gatesgarth"
+LAYERSERIES_COMPAT_acpi = "dunfell gatesgarth hardknott"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_acpi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_acpi = "6"
 
 LAYERDEPENDS_acpi = "intel"
-LAYERSERIES_COMPAT_acpi = "dunfell"
+LAYERSERIES_COMPAT_acpi = "dunfell gatesgarth"

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -31,6 +31,7 @@ IASLFLAGS = " \
     ${@bb.utils.contains('ACPI_FEATURES', 'uart_4w', '-DMUX_UART_4WIRE', '', d)} \
     ${@bb.utils.contains('ACPI_FEATURES', 'i2c', '-DMUX_I2C', '', d)} \
     ${@bb.utils.contains('ACPI_FEATURES', 'spi', '-DMUX_SPI', '', d)} \
+    ${@bb.utils.contains('ACPI_FEATURES', 'i2s', '-DMUX_I2S', '', d)} \
     ${@bb.utils.contains('ACPI_FEATURES', 'uart0', '-DMUX_UART0', '', d)} \
 "
 

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -10,6 +10,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD;md5=377548
 
 DEPENDS = "acpica-native"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files/${BPN}:"
+
 SRC_URI = "\
 	file://acpi-tables-load.service \
 	file://acpi-tables-load \
@@ -18,6 +20,8 @@ SRC_URI = "\
 B = "${WORKDIR}/acpi-tables"
 
 inherit deploy
+
+RDEPENDS_${PN}_edison = "libgpiod"
 
 ACPI_TABLES ?= ""
 ACPI_TABLES[doc] = "List of ACPI tables to include with the initrd"

--- a/recipes-bsp/acpi-tables/acpi-tables.bb
+++ b/recipes-bsp/acpi-tables/acpi-tables.bb
@@ -21,7 +21,7 @@ B = "${WORKDIR}/acpi-tables"
 
 inherit deploy
 
-RDEPENDS_${PN}_edison = "libgpiod"
+RDEPENDS_${PN}_edison = "libgpiod-tools"
 
 ACPI_TABLES ?= ""
 ACPI_TABLES[doc] = "List of ACPI tables to include with the initrd"

--- a/recipes-bsp/acpi-tables/files/edison/acpi-tables-load
+++ b/recipes-bsp/acpi-tables/files/edison/acpi-tables-load
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This script loads all ACPI tables from /kernel/firmware/acpi
+# You must have configfs enabled for this to work
+
+    find /kernel/firmware/acpi/ -type f -name "*.aml" 2>/dev/null | while read TABLE; do
+        dest_dir=$(basename $TABLE .aml)
+        mkdir /sys/kernel/config/acpi/table/$dest_dir
+        cat $TABLE > /sys/kernel/config/acpi/table/$dest_dir/aml
+    done
+
+    sleep 0.1
+    gpioset `gpiofind TRI_STATE_ALL`=0
+    gpioset `gpiofind TRI_STATE_ALL`=1

--- a/recipes-bsp/acpi-tables/files/edison/acpi-tables-load
+++ b/recipes-bsp/acpi-tables/files/edison/acpi-tables-load
@@ -8,6 +8,6 @@
         cat $TABLE > /sys/kernel/config/acpi/table/$dest_dir/aml
     done
 
-    sleep 0.1
+    sleep 0.2
     gpioset `gpiofind TRI_STATE_ALL`=0
     gpioset `gpiofind TRI_STATE_ALL`=1

--- a/recipes-bsp/acpica/acpica_20210105.bb
+++ b/recipes-bsp/acpica/acpica_20210105.bb
@@ -10,14 +10,14 @@ HOMEPAGE = "http://www.acpica.org/"
 SECTION = "console/tools"
 
 LICENSE = "Intel | BSD | GPLv2"
-LIC_FILES_CHKSUM = "file://source/compiler/aslcompile.c;beginline=7;endline=150;md5=6adbcb81e9ee6ae50c569b94fe12f7c5"
+LIC_FILES_CHKSUM = "file://source/compiler/aslcompile.c;beginline=7;endline=150;md5=c33ce358fdcd142684e41e336b7992e8"
 
 COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64).*-linux"
 
 DEPENDS = "m4-native flex-native bison-native"
 
 SRC_URI = "https://acpica.org/sites/acpica/files/acpica-unix-${PV}.tar.gz"
-SRC_URI[sha256sum] = "d44388e21e3d2e47c6d39e9c897935d3f775f04fec76271dcba072c74f834589"
+SRC_URI[sha256sum] = "a9be7b749025e60f93fde2fe531bfe0d84a33641d3e0c9b0f6049f996dbb1ff8"
 
 UPSTREAM_CHECK_URI = "https://acpica.org/downloads"
 
@@ -34,6 +34,8 @@ EXTRA_OEMAKE = "CC='${CC}' \
                 PREFIX=${prefix} \
                 INSTALLDIR=${bindir} \
                 INSTALLFLAGS= \
+                YACC=bison \
+                YFLAGS='-y --file-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}' \
                 "
 
 do_install() {


### PR DESCRIPTION
Patches here include some longstanding Intel Edison specific. If you don't like these, no matter. meta-intel-edison doesn't pull from here directly but from edison-fw/meta-acpi/appropriate-branch.

The most recent 3 indicate compatibility of this layer with Dunfell, Gatesgarth and Hardknott. As well as an update for acpica.